### PR TITLE
Fixing default SameSite value to None for chrome browser cross site cookie issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ coverage
 *.egg-info
 dist
 *.pyc
+.vscode/


### PR DESCRIPTION
This will allow the `oidc_id_cookie_name` cookie to be sent from cross sites in chrome version 80. Until Flask treats the `None` type as a string value for the cookie, this will be required.


> `set_cookie(key, value='', max_age=None, expires=None, path='/', domain=None, secure=False, httponly=False, samesite=None)`